### PR TITLE
Add wearable bridge to post walk sessions from watch

### DIFF
--- a/APP/.gitignore
+++ b/APP/.gitignore
@@ -599,4 +599,4 @@ terraform.tfvars.secret
 *.auto.tfvars.secret
 
 # APP/lib은 반영되어야 함
-!APP/lib/
+!lib/

--- a/APP/android/app/build.gradle.kts
+++ b/APP/android/app/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+    implementation("com.google.android.gms:play-services-wearable:18.2.0")
 }
 
 flutter { source = "../.." }

--- a/APP/android/app/src/main/AndroidManifest.xml
+++ b/APP/android/app/src/main/AndroidManifest.xml
@@ -69,6 +69,14 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name=".WearableListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.BIND_LISTENER" />
+            </intent-filter>
+        </service>
+
         <!-- Kakao 로그인 커스텀 탭 리다이렉트 -->
         <activity
             android:name="com.kakao.sdk.flutter.AuthCodeCustomTabsActivity"

--- a/APP/android/app/src/main/kotlin/com/example/project/MainActivity.kt
+++ b/APP/android/app/src/main/kotlin/com/example/project/MainActivity.kt
@@ -1,5 +1,16 @@
 package com.example.project
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        WearBridge.bind(flutterEngine.dartExecutor.binaryMessenger)
+    }
+
+    override fun detachFromFlutterEngine() {
+        super.detachFromFlutterEngine()
+        WearBridge.unbind()
+    }
+}

--- a/APP/android/app/src/main/kotlin/com/example/project/WearBridge.kt
+++ b/APP/android/app/src/main/kotlin/com/example/project/WearBridge.kt
@@ -1,0 +1,89 @@
+package com.example.project
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import java.util.Collections
+import java.util.LinkedList
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Shares a single [MethodChannel] instance between the foreground Flutter activity
+ * and the [WearableListenerService]. The watch sends JSON payloads through the
+ * data layer; once they arrive here we forward them to Flutter so that the
+ * existing walk posting flow can handle them just like a manual walk session.
+ */
+object WearBridge {
+
+    private const val CHANNEL_NAME = "com.example.project/wear"
+    private const val TAG = "WearBridge"
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    @Volatile
+    private var methodChannel: MethodChannel? = null
+
+    private val pendingEvents = Collections.synchronizedList(
+        LinkedList<Pair<String, Map<String, Any>>>()
+    )
+
+    fun bind(binaryMessenger: BinaryMessenger) {
+        mainHandler.post {
+            methodChannel = MethodChannel(binaryMessenger, CHANNEL_NAME)
+            Log.d(TAG, "MethodChannel bound to Flutter engine")
+            flushPending()
+        }
+    }
+
+    fun unbind() {
+        mainHandler.post {
+            methodChannel = null
+            Log.d(TAG, "MethodChannel unbound from Flutter engine")
+        }
+    }
+
+    fun sendStart(startEpochMs: Long, intensity: String) {
+        dispatch(
+            method = "start_walk",
+            args = mapOf("startEpochMs" to startEpochMs, "intensity" to intensity),
+        )
+    }
+
+    fun sendEnd(endEpochMs: Long, durationSec: Int, intensity: String) {
+        dispatch(
+            method = "end_walk",
+            args = mapOf(
+                "endEpochMs" to endEpochMs,
+                "durationSec" to durationSec,
+                "intensity" to intensity,
+            ),
+        )
+    }
+
+    private fun dispatch(method: String, args: Map<String, Any>) {
+        val channel = methodChannel
+        if (channel == null) {
+            Log.w(TAG, "Flutter channel not ready. Queuing $method with args=$args")
+            pendingEvents += method to args
+            return
+        }
+        mainHandler.post {
+            channel.invokeMethod(method, args)
+        }
+    }
+
+    private fun flushPending() {
+        val snapshot = mutableListOf<Pair<String, Map<String, Any>>>()
+        synchronized(pendingEvents) {
+            if (pendingEvents.isEmpty()) return
+            snapshot += pendingEvents
+            pendingEvents.clear()
+        }
+        snapshot.forEach { (method, args) ->
+            methodChannel?.let { channel ->
+                mainHandler.post { channel.invokeMethod(method, args) }
+            }
+        }
+    }
+}

--- a/APP/android/app/src/main/kotlin/com/example/project/WearableListenerService.kt
+++ b/APP/android/app/src/main/kotlin/com/example/project/WearableListenerService.kt
@@ -1,0 +1,37 @@
+package com.example.project
+
+import android.util.Log
+import com.google.android.gms.wearable.MessageEvent
+import com.google.android.gms.wearable.WearableListenerService
+import org.json.JSONObject
+
+class WearableListenerService : WearableListenerService() {
+    override fun onMessageReceived(messageEvent: MessageEvent) {
+        when (messageEvent.path) {
+            "/walk/start" -> {
+                val data = JSONObject(String(messageEvent.data))
+                val startEpochMs = data.getLong("startEpochMs")
+                val intensity = data.getString("intensity")
+                WearBridge.sendStart(startEpochMs = startEpochMs, intensity = intensity)
+            }
+            "/walk/end" -> {
+                val data = JSONObject(String(messageEvent.data))
+                val endEpochMs = data.getLong("endEpochMs")
+                val durationSec = data.getInt("durationSec")
+                val intensity = data.getString("intensity")
+                WearBridge.sendEnd(
+                    endEpochMs = endEpochMs,
+                    durationSec = durationSec,
+                    intensity = intensity,
+                )
+            }
+            else -> {
+                Log.w(
+                    "WearListener",
+                    "Unhandled wear message path=${messageEvent.path}",
+                )
+                super.onMessageReceived(messageEvent)
+            }
+        }
+    }
+}

--- a/APP/lib/wear_bridge.dart
+++ b/APP/lib/wear_bridge.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Channel name used to exchange messages between the Android bridge and
+/// Flutter. This must stay in sync with [WearBridge.CHANNEL_NAME] on Android.
+const _channelName = 'com.example.project/wear';
+
+/// A watch session start payload coming from the wearable device.
+class WearStartPayload {
+  const WearStartPayload({required this.startUtc, required this.intensity});
+
+  factory WearStartPayload.fromMap(Map<String, dynamic> map) {
+    return WearStartPayload(
+      startUtc: DateTime.fromMillisecondsSinceEpoch(
+        (map['startEpochMs'] as num).toInt(),
+        isUtc: true,
+      ),
+      intensity: map['intensity'] as String? ?? '보통',
+    );
+  }
+
+  final DateTime startUtc;
+  final String intensity;
+}
+
+/// A watch session end payload coming from the wearable device.
+class WearEndPayload {
+  const WearEndPayload({
+    required this.endUtc,
+    required this.durationSec,
+    required this.intensity,
+  });
+
+  factory WearEndPayload.fromMap(Map<String, dynamic> map) {
+    return WearEndPayload(
+      endUtc: DateTime.fromMillisecondsSinceEpoch(
+        (map['endEpochMs'] as num).toInt(),
+        isUtc: true,
+      ),
+      durationSec: (map['durationSec'] as num).toInt(),
+      intensity: map['intensity'] as String? ?? '보통',
+    );
+  }
+
+  final DateTime endUtc;
+  final int durationSec;
+  final String intensity;
+
+  Duration get duration => Duration(seconds: durationSec);
+
+  DateTime inferStartUtc() => endUtc.subtract(duration);
+}
+
+/// Combined walk record inferred from paired start/end events.
+class WearWalkRecord {
+  const WearWalkRecord({
+    required this.startUtc,
+    required this.endUtc,
+    required this.duration,
+    required this.intensity,
+  });
+
+  final DateTime startUtc;
+  final DateTime endUtc;
+  final Duration duration;
+  final String intensity;
+}
+
+/// Thin wrapper around a [MethodChannel] that exposes start/end events as
+/// streams to the Flutter layer.
+class WearMessageChannel {
+  WearMessageChannel._() {
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  static final WearMessageChannel instance = WearMessageChannel._();
+
+  final MethodChannel _channel = const MethodChannel(_channelName);
+  final _startController = StreamController<WearStartPayload>.broadcast();
+  final _endController = StreamController<WearEndPayload>.broadcast();
+
+  Stream<WearStartPayload> get onStart => _startController.stream;
+  Stream<WearEndPayload> get onEnd => _endController.stream;
+
+  Future<void> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'start_walk':
+        final map = Map<String, dynamic>.from(call.arguments as Map);
+        _startController.add(WearStartPayload.fromMap(map));
+        break;
+      case 'end_walk':
+        final map = Map<String, dynamic>.from(call.arguments as Map);
+        _endController.add(WearEndPayload.fromMap(map));
+        break;
+      default:
+        throw MissingPluginException('Unknown wear method: ${call.method}');
+    }
+  }
+}
+
+/// Wires the wearable events to the existing walk posting flow. Call
+/// [WearWalkSync.initialize] once during app start with the handler that
+/// performs the actual network/database work. The handler will be invoked every
+/// time the wearable sends a complete walk session (start + end).
+class WearWalkSync {
+  WearWalkSync._(this._onRecord) {
+    _subscriptions.add(
+      WearMessageChannel.instance.onStart.listen(_handleStart),
+    );
+    _subscriptions.add(
+      WearMessageChannel.instance.onEnd.listen(_handleEnd),
+    );
+  }
+
+  final Future<void> Function(WearWalkRecord record) _onRecord;
+  final List<StreamSubscription<dynamic>> _subscriptions = [];
+  WearStartPayload? _latestStart;
+
+  static WearWalkSync? _instance;
+
+  static WearWalkSync initialize(
+    Future<void> Function(WearWalkRecord record) onRecord,
+  ) {
+    return _instance ??= WearWalkSync._(onRecord);
+  }
+
+  static WearWalkSync? get instance => _instance;
+
+  void dispose() {
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
+    if (identical(_instance, this)) {
+      _instance = null;
+    }
+  }
+
+  void _handleStart(WearStartPayload payload) {
+    _latestStart = payload;
+    debugPrint('[WearWalkSync] Received start: ${payload.startUtc}');
+  }
+
+  void _handleEnd(WearEndPayload payload) {
+    final startUtc = (_latestStart?.startUtc ?? payload.inferStartUtc()).toUtc();
+    final intensity = payload.intensity;
+    final record = WearWalkRecord(
+      startUtc: startUtc,
+      endUtc: payload.endUtc.toUtc(),
+      duration: payload.duration,
+      intensity: intensity,
+    );
+    _latestStart = null;
+    debugPrint('[WearWalkSync] Received end: ${record.endUtc} (duration: ${record.duration})');
+    unawaited(_onRecord(record));
+  }
+}


### PR DESCRIPTION
## Summary
- expose a Flutter-side wear bridge that surfaces start/end walk events and invokes the existing walk posting flow
- forward wearable messages through an Android service and method channel so walks end immediately propagate to the app
- register the listener service and add the wearable play services dependency; ensure APP/lib is tracked by git

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d96ef1e3a483329b6b41a541945b63